### PR TITLE
fix: Update dependencies to resolve security vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ vendor/
 # Ruby
 *.gem
 .bundle
-Gemfile.lock
+# Gemfile.lock should be committed for applications (uncommented for better dependency management)
 
 # IDE
 .idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,208 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    exifr (1.4.1)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    fspath (3.1.2)
+    google-protobuf (4.33.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    image_optim (0.31.4)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (>= 1.5, < 4)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    image_optim_pack (0.12.2)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+    image_optim_pack (0.12.2-arm64-darwin)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+    image_optim_pack (0.12.2-x86_64-darwin)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+    image_optim_pack (0.12.2-x86_64-linux)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
+    image_size (3.4.0)
+    in_threads (1.6.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-image-optim (1.0.6)
+      image_optim (~> 0.26)
+      image_optim_pack (~> 0.5)
+    jekyll-paginate (1.1.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    plainwhite (0.13)
+      jekyll (>= 3.7.3)
+      jekyll-seo-tag (>= 2.1.0)
+    progress (3.6.0)
+    public_suffix (6.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    rubyzip (2.4.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.94.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.94.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  http_parser.rb (~> 0.6.0)
+  jekyll (~> 4.3.2)
+  jekyll-feed (~> 0.17.0)
+  jekyll-image-optim
+  jekyll-paginate (~> 1.1.0)
+  jekyll-remote-theme
+  jekyll-seo-tag (~> 2.8.0)
+  jekyll-sitemap (~> 1.4.0)
+  plainwhite
+  tzinfo (>= 1, < 3)
+  tzinfo-data
+  wdm (~> 0.1.1)
+
+BUNDLED WITH
+   2.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==3.0.2
+Flask==3.1.0
 Flask-Login==0.6.3
 python-dotenv==1.0.1
-Werkzeug==3.0.1
-PyGithub==2.2.0
-Markdown==3.5.2
+Werkzeug==3.1.3
+PyGithub==2.5.0
+Markdown==3.7
 python-frontmatter==1.1.0
-Pillow==10.2.0 
+Pillow==11.0.0 


### PR DESCRIPTION
Security Updates:
- Update all Ruby gems via bundle update
  * Jekyll 4.3.4 (latest stable)
  * Updated all plugins to latest compatible versions
- Update Python packages to latest secure versions:
  * Flask: 3.0.2 → 3.1.0
  * Werkzeug: 3.0.1 → 3.1.3
  * PyGithub: 2.2.0 → 2.5.0
  * Markdown: 3.5.2 → 3.7
  * Pillow: 10.2.0 → 11.0.0 (critical security updates)

Changes:
- Add Gemfile.lock to repository for consistent builds
- Update .gitignore to track Gemfile.lock (best practice for apps)
- Update requirements.txt with latest secure versions

This resolves the 4 vulnerabilities (2 high, 2 moderate) detected by GitHub Dependabot security scanning.

Recommended: Review and merge Dependabot PRs regularly to stay secure.