### PR TITLE
chore(dependabot): drop pip ecosystem for removed Flask CMS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,18 +24,3 @@ updates:
       jekyll-plugins:
         patterns:
           - "jekyll-*"
-
-  # Maintain dependencies for pip (Python/Flask CMS)
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "python"
-    groups:
-      flask-dependencies:
-        patterns:
-          - "Flask*"
-          - "Werkzeug"


### PR DESCRIPTION
The Flask CMS was removed from the repo (no `requirements.txt`, `app/`, or `run.py`), but `.github/dependabot.yml` still had a `pip` ecosystem block. That caused Dependabot to keep opening Python dependency PRs against files that no longer exist — most landed as `CONFLICTING`.

This removes the `pip` block. The `github-actions` and `bundler` (Ruby/Jekyll) updaters are unchanged.

The 7 stale Python PRs (#15, #17, #18, #19, #22, #26, #27) have been closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)