### PR TITLE
build(deps): bump concurrent-ruby from 1.3.6 to 1.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)


### PR DESCRIPTION
Manual replacement for Dependabot #35, which repeatedly failed to rebase itself against `master` with an internal Dependabot error ("something went wrong").

`concurrent-ruby` 1.3.6 → 1.3.7 — a leaf gem, patch release, no dependency changes. Single-line bump in `Gemfile.lock`.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)